### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ Code for recharging a robot infinitely in the 2020 FRC game Infinite Recharge
 After gradle has synced, either use the gradle menu to run
 > Tasks > help > addKtlintFormatGitPreCommitHook
 
-or in your commandline, run
+For Windows, open the commandline and run
+
+```
+chmod +x gradlew
+./gradlew addKtlintFormatGitPreCommitHook
+```
+
+For linux, run 
 
 ```
 chmod +x gradlew


### PR DESCRIPTION
You could say that I'm updating the READ.ME
For linux, you need to use
```
chmod +x gradlew
```
because bash files are not by default executable.
In windows this is not necessary.
I am not sure about MacOS. @mckelveygreg do you need to do this on apple?