### PR TITLE
maybe fixed climber limitswitch names

### DIFF
--- a/src/main/kotlin/org/sert2521/infiniterecharge2020/climber/Climber.kt
+++ b/src/main/kotlin/org/sert2521/infiniterecharge2020/climber/Climber.kt
@@ -20,11 +20,11 @@ class Climber : Subsystem("Climber") {
 
     // Ah. Now would be time to look away from the code (or at least not closely)
     // TODO: FIX THESE INCREDIBLE NAMES CORUTSEY OF MOISEUR WILL.I.AM
-    val topLimitSwitch = DigitalInput(BOTTOM_LIMIT_SWITCH)
-    val bottomLimitSwitch = DigitalInput(TOP_LIMIT_SWITCH)
+    val topLimitSwitch = DigitalInput(TOP_LIMIT_SWITCH)
+    val bottomLimitSwitch = DigitalInput(BOTTOM_LIMIT_SWITCH)
 
-    val atBottom get() = topLimitSwitch.get()
-    val atTop get() = !bottomLimitSwitch.get()
+    val atBottom get() = bottomLimitSwitch.get()
+    val atTop get() = topLimitSwitch.get()
 
     var position
         get() = liftMotor.position


### PR DESCRIPTION
Switched the limitswitch variable names so that top goes with top and bottom goes with bottom. There was a `!` sign, was that just part of testing or actual code?